### PR TITLE
Add theming

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var gray = require('ansi-gray');
 var timestamp = require('time-stamp');
 var supportsColor = require('color-support');
 var nodeVersion = require('parse-node-version')(process.version);
+var themingLog = require('theming-log');
 
 var colorDetectionOptions = {
   // If on Windows, ignore the isTTY check
@@ -17,6 +18,7 @@ var colorDetectionOptions = {
 // Needed to add this because node 10 decided to start coloring log output
 // randomly
 var console;
+/* istanbul ignore else */
 if (nodeVersion.major >= 10) {
   // Node 10 also changed the way this is constructed
   console = new Console({
@@ -49,43 +51,58 @@ function addColor(str) {
 }
 
 function getTimestamp() {
-  return '[' + addColor(timestamp('HH:mm:ss')) + ']';
+  return themingLog.format(log.theme, '{TIMESTAMP.FORMAT}');
 }
 
 function log() {
   var time = getTimestamp();
-  process.stdout.write(time + ' ');
+  process.stdout.write(time);
   console.log.apply(console, arguments);
   return this;
 }
 
+Object.defineProperty(log, 'theme', {
+  value: {
+    NOW: timestamp,
+    TIMESTAMP: {
+      COLOR: addColor,
+      FORMAT: '[{TIMESTAMP.COLOR: {NOW: HH:mm:ss}}] ',
+    },
+  },
+});
+
 function info() {
   var time = getTimestamp();
-  process.stdout.write(time + ' ');
+  process.stdout.write(time);
   console.info.apply(console, arguments);
   return this;
 }
 
 function dir() {
   var time = getTimestamp();
-  process.stdout.write(time + ' ');
+  process.stdout.write(time);
   console.dir.apply(console, arguments);
   return this;
 }
 
 function warn() {
   var time = getTimestamp();
-  process.stderr.write(time + ' ');
+  process.stderr.write(time);
   console.warn.apply(console, arguments);
   return this;
 }
 
 function error() {
   var time = getTimestamp();
-  process.stderr.write(time + ' ');
+  process.stderr.write(time);
   console.error.apply(console, arguments);
   return this;
 }
+
+log.themed = themingLog(log.theme, log, true);
+info.themed = themingLog(log.theme, info, true);
+warn.themed = themingLog(log.theme, warn, true);
+error.themed = themingLog(log.theme, error, true);
 
 module.exports = log;
 module.exports.info = info;

--- a/index.js
+++ b/index.js
@@ -8,12 +8,14 @@ var nodeVersion = require('parse-node-version')(process.version);
 
 var colorDetectionOptions = {
   // If on Windows, ignore the isTTY check
-  // This is due to AppVeyor (and thus probably common Windows platforms?) failing the check
+  // This is due to AppVeyor (and thus probably common Windows platforms?)
+  // failing the check
   // TODO: If this is too broad, we can reduce it to an APPVEYOR env check
   ignoreTTY: (process.platform === 'win32'),
 };
 
-// Needed to add this because node 10 decided to start coloring log output randomly
+// Needed to add this because node 10 decided to start coloring log output
+// randomly
 var console;
 if (nodeVersion.major >= 10) {
   // Node 10 also changed the way this is constructed

--- a/package.json
+++ b/package.json
@@ -28,9 +28,14 @@
     "ansi-gray": "^0.1.1",
     "color-support": "^1.1.3",
     "parse-node-version": "^1.0.0",
+    "theming-log": "^2.1.1",
     "time-stamp": "^1.0.0"
   },
   "devDependencies": {
+    "ansi-blue": "^0.1.1",
+    "ansi-green": "^0.1.1",
+    "ansi-red": "^0.1.1",
+    "ansi-yellow": "^0.1.1",
     "eslint": "^2.13.0",
     "eslint-config-gulp": "^3.0.1",
     "expect": "^1.20.2",

--- a/test/theming.js
+++ b/test/theming.js
@@ -1,0 +1,305 @@
+'use strict';
+
+var expect = require('expect');
+var timestamp = require('time-stamp');
+var red = require('ansi-red');
+var blue = require('ansi-blue');
+var gray = require('ansi-gray');
+var green = require('ansi-green');
+var yellow = require('ansi-yellow');
+
+var log = require('../');
+
+var stdoutSpy = expect.spyOn(process.stdout, 'write').andCallThrough();
+var stderrSpy = expect.spyOn(process.stderr, 'write').andCallThrough();
+
+before(function(done) {
+  log.theme.color = {
+    red: red,
+    blue: blue,
+    gray: gray,
+    green: green,
+    yellow: yellow,
+  };
+  done();
+});
+
+describe('timestamp', function() {
+
+  var timestampFormat, timestampColor;
+
+  before(function(done) {
+    timestampFormat = log.theme.TIMESTAMP.FORMAT;
+    timestampColor = log.theme.TIMESTAMP.COLOR;
+    done();
+  });
+
+  after(function(done) {
+    log.theme.TIMESTAMP.FORMAT = timestampFormat;
+    log.theme.TIMESTAMP.COLOR = timestampColor;
+    done();
+  });
+
+  beforeEach(function(done) {
+    stdoutSpy.reset();
+    stderrSpy.reset();
+    done();
+  });
+
+  it('should change timestamp color', function(done) {
+    log.theme.TIMESTAMP.COLOR = red;
+    log(1, 2, 3, 4, 'five');
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls[0].arguments[0]).toEqual('[' + red(time) + '] ');
+    expect(stdoutSpy.calls[1].arguments[0]).toEqual('1 2 3 4 \'five\'\n');
+
+    log.theme.TIMESTAMP.COLOR = '{color.green:{1}}';
+    log(1, 2, 3, 4, 'five');
+    time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls[2].arguments[0]).toEqual('[' + green(time) + '] ');
+    expect(stdoutSpy.calls[3].arguments[0]).toEqual('1 2 3 4 \'five\'\n');
+    expect(stderrSpy.calls.length).toEqual(0);
+
+    done();
+  });
+
+  it('should change timestamp format', function(done) {
+    log.theme.TIMESTAMP.COLOR = blue;
+    log.theme.TIMESTAMP.FORMAT =
+      '{TIMESTAMP.COLOR: ({NOW: YYYY/MM/DD HH:mm:ss})} : ';
+    log(1, 2, 3, 4, 'five');
+    var time = timestamp('YYYY/MM/DD HH:mm:ss');
+
+    expect(stdoutSpy.calls[0].arguments[0])
+      .toEqual(blue('(' + time + ')') + ' : ');
+    expect(stdoutSpy.calls[1].arguments[0])
+      .toEqual('1 2 3 4 \'five\'\n');
+    expect(stderrSpy.calls.length).toEqual(0);
+
+    done();
+  });
+});
+
+describe('log.themed', function() {
+
+  before(function(done) {
+    log.theme.MSG = '{color.green: {1}}';
+    done();
+  });
+
+  beforeEach(function(done) {
+    stdoutSpy.reset();
+    done();
+  });
+
+  it('should output themed log', function(done) {
+    log.themed('{MSG: This is {1} of {2}.}', 'A', 'B');
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stdoutSpy.calls[1].arguments[0])
+      .toEqual(green('This is A of B.') + '\n');
+    expect(stderrSpy.calls.length).toEqual(0);
+
+    done();
+  });
+
+  it('should output other format', function(done) {
+    log.themed('{MSG: This is {2}\'s {1}.}', 'A', 'B');
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stdoutSpy.calls[1].arguments[0])
+      .toEqual(green('This is B\'s A.') + '\n');
+    expect(stderrSpy.calls.length).toEqual(0);
+
+    done();
+  });
+
+  it('should output in other language', function(done) {
+    log.themed('{MSG: これは{2}の{1}です。}', 'A', 'B');
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stdoutSpy.calls[1].arguments[0])
+      .toEqual(green('これはBのAです。') + '\n');
+    expect(stderrSpy.calls.length).toEqual(0);
+
+    done();
+  });
+
+  it('should output multiple logs by lines', function(done) {
+    log.themed(
+      '{MSG: This is first message.}\n' +
+      '{MSG: This is second message.}'
+    );
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stdoutSpy.calls[1].arguments[0])
+      .toEqual(green('This is first message.') + '\n');
+
+    expect(stdoutSpy.calls[2].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stdoutSpy.calls[3].arguments[0])
+      .toEqual(green('This is second message.') + '\n');
+
+    expect(stderrSpy.calls.length).toEqual(0);
+
+    done();
+  });
+});
+
+describe('log.info.themed', function() {
+
+  before(function(done) {
+    log.theme.INFO = '{color.blue: {1}}';
+    done();
+  });
+
+  beforeEach(function(done) {
+    stdoutSpy.reset();
+    stderrSpy.reset();
+    done();
+  });
+
+  it('should output themed info log', function(done) {
+    log.info.themed('{INFO: This is {1} of {2}.}', 'A', 'B');
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stdoutSpy.calls[1].arguments[0])
+      .toEqual(blue('This is A of B.') + '\n');
+    expect(stderrSpy.calls.length).toEqual(0);
+
+    done();
+  });
+
+  it('should output multiple logs by lines', function(done) {
+    log.info.themed(
+      '{INFO: This is first message.}\n' +
+      '{INFO: This is second message.}'
+    );
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stdoutSpy.calls[1].arguments[0])
+      .toEqual(blue('This is first message.') + '\n');
+
+    expect(stdoutSpy.calls[2].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stdoutSpy.calls[3].arguments[0])
+      .toEqual(blue('This is second message.') + '\n');
+
+    expect(stderrSpy.calls.length).toEqual(0);
+
+    done();
+  });
+});
+
+describe('log.warn.themed', function() {
+
+  before(function(done) {
+    log.theme.WARN = '{color.yellow: {1}}';
+    done();
+  });
+
+  beforeEach(function(done) {
+    stdoutSpy.reset();
+    stderrSpy.reset();
+    done();
+  });
+
+  it('should output themed warn log', function(done) {
+    log.warn.themed('{WARN: This is {1} of {2}.}', 'A', 'B');
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls.length).toEqual(0);
+    expect(stderrSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stderrSpy.calls[1].arguments[0])
+      .toEqual(yellow('This is A of B.') + '\n');
+
+    done();
+  });
+
+  it('should output multiple logs by lines', function(done) {
+    log.warn.themed(
+      '{WARN: This is first message.}\n' +
+      '{WARN: This is second message.}'
+    );
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls.length).toEqual(0);
+
+    expect(stderrSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stderrSpy.calls[1].arguments[0])
+      .toEqual(yellow('This is first message.') + '\n');
+
+    expect(stderrSpy.calls[2].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stderrSpy.calls[3].arguments[0])
+      .toEqual(yellow('This is second message.') + '\n');
+
+    done();
+  });
+});
+
+describe('log.error.themed', function() {
+
+  before(function(done) {
+    log.theme.ERROR = '{color.red: {1}}';
+    done();
+  });
+
+  beforeEach(function(done) {
+    stdoutSpy.reset();
+    stderrSpy.reset();
+    done();
+  });
+
+  it('should output themed error log', function(done) {
+    log.error.themed('{ERROR: This is {1} of {2}.}', 'A', 'B');
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls.length).toEqual(0);
+
+    expect(stderrSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stderrSpy.calls[1].arguments[0])
+      .toEqual(red('This is A of B.') + '\n');
+
+    done();
+  });
+
+  it('should output multiple logs by lines', function(done) {
+    log.error.themed(
+      '{ERROR: This is first message.}\n' +
+      '{ERROR: This is second message.}'
+    );
+    var time = timestamp('HH:mm:ss');
+
+    expect(stdoutSpy.calls.length).toEqual(0);
+
+    expect(stderrSpy.calls[0].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stderrSpy.calls[1].arguments[0])
+      .toEqual(red('This is first message.') + '\n');
+
+    expect(stderrSpy.calls[2].arguments[0])
+      .toEqual('[' + gray(time) + '] ');
+    expect(stderrSpy.calls[3].arguments[0])
+      .toEqual(red('This is second message.') + '\n');
+
+    done();
+  });
+});


### PR DESCRIPTION
This pr enable to output themed logs by using [theming-log](https://github.com/sttk/theming-log). This will solve some issues about coloring of this module and gulp-cli.

This adds following four functions and one property:

* `log.themed(msg [, ...args])`
* `log.info.themed(msg [, ...args])`
* `log.warn.themed(msg [, ...args])`
* `log.error.themed(msg [, ...args])`
* `log.theme`

```
log.theme.MSG = ansi.green
log.theme.INFO = ansi.blue
log.theme.ERROR = ansi.red
log.theme.WARN = ansi.yellow

log.themed('{MSG: This is a message. }')  // => Output the message in green.
log.info.themed('{INFO: This is a message. }')  // => Output the message in blue.
log.error.themed('{ERROR: This is a message. }')  // => Output the message in red.
log.warn.themed('{WARN: This is a message. }')  // => Output the message in yellow.
```
 
Also, this pr enable to customize timestamp color and format by innate properties in `log.theme`.

```
log.theme.TIMESTAMP.COLOR = ansi.magenta
log.themed('{MSG: This is a message. }')  // => Output the timestamp in magenta.

log.theme.TIMESTAMP.FORMAT = '({TIMESTAMP.COLOR: {NOW: YYYY/MM/DD HH:mm:ss}}) '
log.themed('{MSG: This is a message. }')  // => Output the timestamp like '(2018/12/22 18:53:21) '.
```